### PR TITLE
Changes to run_XXX scripts for ZUBoard

### DIFF
--- a/recipes-app/camera-setup/files/zub1cg-sbc/load_camera_config.sh
+++ b/recipes-app/camera-setup/files/zub1cg-sbc/load_camera_config.sh
@@ -64,8 +64,14 @@ fi
 
 cat /boot/devicetree/$1.dtbo > /sys/kernel/config/device-tree/overlays/ap1302/dtbo
 
-sed -i -E "s/INPUT_RESOLUTION=[0-9]+x[0-9]+/INPUT_RESOLUTION=$CAMERA_RESOLUTION/g" $(which run_1920_1080)
-sed -i -E "s/INPUT_RESOLUTION=[0-9]+x[0-9]+/INPUT_RESOLUTION=$CAMERA_RESOLUTION/g" $(which run_3840_2160)
+sed -i -E "s/INPUT_RESOLUTION=[0-9]+x[0-9]+/INPUT_RESOLUTION=$CAMERA_RESOLUTION/g" $(which run_1280_480_rgb)
+sed -i -E "s/INPUT_RESOLUTION=[0-9]+x[0-9]+/INPUT_RESOLUTION=$CAMERA_RESOLUTION/g" $(which run_1280_480_yuv422)
+sed -i -E "s/INPUT_RESOLUTION=[0-9]+x[0-9]+/INPUT_RESOLUTION=$CAMERA_RESOLUTION/g" $(which run_1920_1080_rgb)
+sed -i -E "s/INPUT_RESOLUTION=[0-9]+x[0-9]+/INPUT_RESOLUTION=$CAMERA_RESOLUTION/g" $(which run_1920_1080_yuv422)
+sed -i -E "s/INPUT_RESOLUTION=[0-9]+x[0-9]+/INPUT_RESOLUTION=$CAMERA_RESOLUTION/g" $(which run_2560_800_rgb)
+sed -i -E "s/INPUT_RESOLUTION=[0-9]+x[0-9]+/INPUT_RESOLUTION=$CAMERA_RESOLUTION/g" $(which run_2560_800_yuv422)
+sed -i -E "s/INPUT_RESOLUTION=[0-9]+x[0-9]+/INPUT_RESOLUTION=$CAMERA_RESOLUTION/g" $(which run_640_480_rgb)
+sed -i -E "s/INPUT_RESOLUTION=[0-9]+x[0-9]+/INPUT_RESOLUTION=$CAMERA_RESOLUTION/g" $(which run_640_480_yuv422)
 
 # Remount /Boot if it was previously mounted
 if [ $BOOT_NOT_MOUNTED -eq 0 ]

--- a/recipes-app/run-1920-1080/files/zub1cg-sbc/run_1280_480_rgb.sh
+++ b/recipes-app/run-1920-1080/files/zub1cg-sbc/run_1280_480_rgb.sh
@@ -8,10 +8,10 @@ OUTPUT_RESOLUTION=${OUTPUT_W}x${OUTPUT_H}
 # Specify MIPI capture pipeline devices
 mipi_video_dev="/dev/video0"
 mipi_media_dev="/dev/media0"
-mipi_ap1302_i2c="ap1302.1-003c"
+mipi_ap1302_i2c="ap1302.0-003c"
 
 # Configure MIPI capture pipeline for RGB
-media-ctl -d ${mipi_media_dev} -V "'ap1302.1-003c':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'${mipi_ap1302_i2c}':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':1 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0010000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
@@ -20,7 +20,7 @@ media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':0 [fmt:RBG24/$INPUT_RESO
 media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':1 [fmt:RBG24/$OUTPUT_RESOLUTION field:none]"
 
 # Turn off AWB for case of AR0144 sensors (monochrome)
-media_ctl=$(media-ctl -p -d /dev/media0)
+media_ctl=$(media-ctl -p -d ${mipi_media_dev})
 if [[ "$media_ctl" == *"ar0144"* ]]; then
 	echo "Detected AR0144 - disabling AWB"
   v4l2-ctl --set-ctrl white_balance_auto_preset=0 -d ${mipi_video_dev}

--- a/recipes-app/run-1920-1080/files/zub1cg-sbc/run_1280_480_yuv422.sh
+++ b/recipes-app/run-1920-1080/files/zub1cg-sbc/run_1280_480_yuv422.sh
@@ -8,10 +8,10 @@ OUTPUT_RESOLUTION=${OUTPUT_W}x${OUTPUT_H}
 # Specify MIPI capture pipeline devices
 mipi_video_dev="/dev/video0"
 mipi_media_dev="/dev/media0"
-mipi_ap1302_i2c="ap1302.1-003c"
+mipi_ap1302_i2c="ap1302.0-003c"
 
 # Configure MIPI capture pipeline for YUV422
-media-ctl -d ${mipi_media_dev} -V "'${mipi_ap1302_dev}':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'${mipi_ap1302_i2c}':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':1 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0010000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
@@ -20,7 +20,7 @@ media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT
 media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':1 [fmt:UYVY8_1X16/$OUTPUT_RESOLUTION field:none]"
 
 # Turn off AWB for case of AR0144 sensors (monochrome)
-media_ctl=$(media-ctl -p -d /dev/media0)
+media_ctl=$(media-ctl -p -d ${mipi_media_dev})
 if [[ "$media_ctl" == *"ar0144"* ]]; then
 	echo "Detected AR0144 - disabling AWB"
   v4l2-ctl --set-ctrl white_balance_auto_preset=0 -d ${mipi_video_dev}

--- a/recipes-app/run-1920-1080/files/zub1cg-sbc/run_1920_1080_rgb.sh
+++ b/recipes-app/run-1920-1080/files/zub1cg-sbc/run_1920_1080_rgb.sh
@@ -8,10 +8,10 @@ OUTPUT_RESOLUTION=${OUTPUT_W}x${OUTPUT_H}
 # Specify MIPI capture pipeline devices
 mipi_video_dev="/dev/video0"
 mipi_media_dev="/dev/media0"
-mipi_ap1302_i2c="ap1302.1-003c"
+mipi_ap1302_i2c="ap1302.0-003c"
 
 # Configure MIPI capture pipeline for RGB
-media-ctl -d ${mipi_media_dev} -V "'ap1302.1-003c':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'${mipi_ap1302_i2c}':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':1 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0010000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
@@ -20,7 +20,7 @@ media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':0 [fmt:RBG24/$INPUT_RESO
 media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':1 [fmt:RBG24/$OUTPUT_RESOLUTION field:none]"
 
 # Turn off AWB for case of AR0144 sensors (monochrome)
-media_ctl=$(media-ctl -p -d /dev/media0)
+media_ctl=$(media-ctl -p -d ${mipi_media_dev})
 if [[ "$media_ctl" == *"ar0144"* ]]; then
 	echo "Detected AR0144 - disabling AWB"
   v4l2-ctl --set-ctrl white_balance_auto_preset=0 -d ${mipi_video_dev}

--- a/recipes-app/run-1920-1080/files/zub1cg-sbc/run_1920_1080_yuv422.sh
+++ b/recipes-app/run-1920-1080/files/zub1cg-sbc/run_1920_1080_yuv422.sh
@@ -8,10 +8,10 @@ OUTPUT_RESOLUTION=${OUTPUT_W}x${OUTPUT_H}
 # Specify MIPI capture pipeline devices
 mipi_video_dev="/dev/video0"
 mipi_media_dev="/dev/media0"
-mipi_ap1302_i2c="ap1302.1-003c"
+mipi_ap1302_i2c="ap1302.0-003c"
 
 # Configure MIPI capture pipeline for YUV422
-media-ctl -d ${mipi_media_dev} -V "'${mipi_ap1302_dev}':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'${mipi_ap1302_i2c}':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':1 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0010000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
@@ -20,7 +20,7 @@ media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT
 media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':1 [fmt:UYVY8_1X16/$OUTPUT_RESOLUTION field:none]"
 
 # Turn off AWB for case of AR0144 sensors (monochrome)
-media_ctl=$(media-ctl -p -d /dev/media0)
+media_ctl=$(media-ctl -p -d ${mipi_media_dev})
 if [[ "$media_ctl" == *"ar0144"* ]]; then
 	echo "Detected AR0144 - disabling AWB"
   v4l2-ctl --set-ctrl white_balance_auto_preset=0 -d ${mipi_video_dev}

--- a/recipes-app/run-1920-1080/files/zub1cg-sbc/run_2560_800_rgb.sh
+++ b/recipes-app/run-1920-1080/files/zub1cg-sbc/run_2560_800_rgb.sh
@@ -8,10 +8,10 @@ OUTPUT_RESOLUTION=${OUTPUT_W}x${OUTPUT_H}
 # Specify MIPI capture pipeline devices
 mipi_video_dev="/dev/video0"
 mipi_media_dev="/dev/media0"
-mipi_ap1302_i2c="ap1302.1-003c"
+mipi_ap1302_i2c="ap1302.0-003c"
 
 # Configure MIPI capture pipeline for RGB
-media-ctl -d ${mipi_media_dev} -V "'ap1302.1-003c':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'${mipi_ap1302_i2c}':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':1 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0010000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
@@ -20,7 +20,7 @@ media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':0 [fmt:RBG24/$INPUT_RESO
 media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':1 [fmt:RBG24/$OUTPUT_RESOLUTION field:none]"
 
 # Turn off AWB for case of AR0144 sensors (monochrome)
-media_ctl=$(media-ctl -p -d /dev/media0)
+media_ctl=$(media-ctl -p -d ${mipi_media_dev})
 if [[ "$media_ctl" == *"ar0144"* ]]; then
 	echo "Detected AR0144 - disabling AWB"
   v4l2-ctl --set-ctrl white_balance_auto_preset=0 -d ${mipi_video_dev}

--- a/recipes-app/run-1920-1080/files/zub1cg-sbc/run_2560_800_yuv422.sh
+++ b/recipes-app/run-1920-1080/files/zub1cg-sbc/run_2560_800_yuv422.sh
@@ -8,10 +8,10 @@ OUTPUT_RESOLUTION=${OUTPUT_W}x${OUTPUT_H}
 # Specify MIPI capture pipeline devices
 mipi_video_dev="/dev/video0"
 mipi_media_dev="/dev/media0"
-mipi_ap1302_i2c="ap1302.1-003c"
+mipi_ap1302_i2c="ap1302.0-003c"
 
 # Configure MIPI capture pipeline for YUV422
-media-ctl -d ${mipi_media_dev} -V "'${mipi_ap1302_dev}':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'${mipi_ap1302_i2c}':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':1 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
 media-ctl -d ${mipi_media_dev} -V "'b0010000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
@@ -20,7 +20,7 @@ media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT
 media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':1 [fmt:UYVY8_1X16/$OUTPUT_RESOLUTION field:none]"
 
 # Turn off AWB for case of AR0144 sensors (monochrome)
-media_ctl=$(media-ctl -p -d /dev/media0)
+media_ctl=$(media-ctl -p -d ${mipi_media_dev})
 if [[ "$media_ctl" == *"ar0144"* ]]; then
 	echo "Detected AR0144 - disabling AWB"
   v4l2-ctl --set-ctrl white_balance_auto_preset=0 -d ${mipi_video_dev}

--- a/recipes-app/run-1920-1080/files/zub1cg-sbc/run_640_480_rgb.sh
+++ b/recipes-app/run-1920-1080/files/zub1cg-sbc/run_640_480_rgb.sh
@@ -5,33 +5,34 @@ OUTPUT_W=640
 OUTPUT_H=480
 OUTPUT_RESOLUTION=${OUTPUT_W}x${OUTPUT_H}
 
-media-ctl -d /dev/media0 -V "'ap1302.0-003c':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+# Specify MIPI capture pipeline devices
+mipi_video_dev="/dev/video0"
+mipi_media_dev="/dev/media0"
+mipi_ap1302_i2c="ap1302.0-003c"
 
-media-ctl -d /dev/media0 -V "'b0000000.mipi_csi2_rx_subsystem':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
-media-ctl -d /dev/media0 -V "'b0000000.mipi_csi2_rx_subsystem':1 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
-
-media-ctl -d /dev/media0 -V "'b0010000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
-media-ctl -d /dev/media0 -V "'b0010000.v_proc_ss':1 [fmt:RBG24/$INPUT_RESOLUTION field:none]"
-
-media-ctl -d /dev/media0 -V "'b0040000.v_proc_ss':0 [fmt:RBG24/$INPUT_RESOLUTION field:none]"
-media-ctl -d /dev/media0 -V "'b0040000.v_proc_ss':1 [fmt:RBG24/$OUTPUT_RESOLUTION field:none]"
-
-sleep 1
+# Configure MIPI capture pipeline for RGB
+media-ctl -d ${mipi_media_dev} -V "'${mipi_ap1302_i2c}':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':1 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'b0010000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'b0010000.v_proc_ss':1 [fmt:RBG24/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':0 [fmt:RBG24/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':1 [fmt:RBG24/$OUTPUT_RESOLUTION field:none]"
 
 # Turn off AWB for case of AR0144 sensors (monochrome)
-media_ctl=$(media-ctl -p -d /dev/media0)
+media_ctl=$(media-ctl -p -d ${mipi_media_dev})
 if [[ "$media_ctl" == *"ar0144"* ]]; then
 	echo "Detected AR0144 - disabling AWB"
-	v4l2-ctl --set-ctrl white_balance_auto_preset=0 -d /dev/video0
+	v4l2-ctl --set-ctrl white_balance_auto_preset=0 -d ${mipi_video_dev}
 	echo "Detected AR0144 - setting brightness"
 	v4l2-ctl --set-ctrl brightness=256 -d ${mipi_video_dev}
 fi
 if [[ "$media_ctl" == *"ar1335"* ]]; then
 	echo "Detected AR1335 - enabling AWB"
-	v4l2-ctl --set-ctrl white_balance_auto_preset=1 -d /dev/video0
+	v4l2-ctl --set-ctrl white_balance_auto_preset=1 -d ${mipi_video_dev}
 fi
 
-gst-launch-1.0 v4l2src device=/dev/video0 io-mode="dmabuf" \
+gst-launch-1.0 v4l2src device=${mipi_video_dev} io-mode="dmabuf" \
 	! "video/x-raw, width=$OUTPUT_W, height=$OUTPUT_H, format=BGR, framerate=60/1" \
 	! videoconvert \
 	! fpsdisplaysink video-sink="autovideosink" text-overlay=false sync=false \

--- a/recipes-app/run-1920-1080/files/zub1cg-sbc/run_640_480_rgb.sh
+++ b/recipes-app/run-1920-1080/files/zub1cg-sbc/run_640_480_rgb.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+INPUT_RESOLUTION=2560x800
+OUTPUT_W=640
+OUTPUT_H=480
+OUTPUT_RESOLUTION=${OUTPUT_W}x${OUTPUT_H}
+
+media-ctl -d /dev/media0 -V "'ap1302.0-003c':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+
+media-ctl -d /dev/media0 -V "'b0000000.mipi_csi2_rx_subsystem':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d /dev/media0 -V "'b0000000.mipi_csi2_rx_subsystem':1 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+
+media-ctl -d /dev/media0 -V "'b0010000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d /dev/media0 -V "'b0010000.v_proc_ss':1 [fmt:RBG24/$INPUT_RESOLUTION field:none]"
+
+media-ctl -d /dev/media0 -V "'b0040000.v_proc_ss':0 [fmt:RBG24/$INPUT_RESOLUTION field:none]"
+media-ctl -d /dev/media0 -V "'b0040000.v_proc_ss':1 [fmt:RBG24/$OUTPUT_RESOLUTION field:none]"
+
+sleep 1
+
+# Turn off AWB for case of AR0144 sensors (monochrome)
+media_ctl=$(media-ctl -p -d /dev/media0)
+if [[ "$media_ctl" == *"ar0144"* ]]; then
+	echo "Detected AR0144 - disabling AWB"
+	v4l2-ctl --set-ctrl white_balance_auto_preset=0 -d /dev/video0
+	echo "Detected AR0144 - setting brightness"
+	v4l2-ctl --set-ctrl brightness=256 -d ${mipi_video_dev}
+fi
+if [[ "$media_ctl" == *"ar1335"* ]]; then
+	echo "Detected AR1335 - enabling AWB"
+	v4l2-ctl --set-ctrl white_balance_auto_preset=1 -d /dev/video0
+fi
+
+gst-launch-1.0 v4l2src device=/dev/video0 io-mode="dmabuf" \
+	! "video/x-raw, width=$OUTPUT_W, height=$OUTPUT_H, format=BGR, framerate=60/1" \
+	! videoconvert \
+	! fpsdisplaysink video-sink="autovideosink" text-overlay=false sync=false \
+	-v

--- a/recipes-app/run-1920-1080/files/zub1cg-sbc/run_640_480_yuv422.sh
+++ b/recipes-app/run-1920-1080/files/zub1cg-sbc/run_640_480_yuv422.sh
@@ -23,6 +23,8 @@ media_ctl=$(media-ctl -p -d /dev/media0)
 if [[ "$media_ctl" == *"ar0144"* ]]; then
 	echo "Detected AR0144 - disabling AWB"
 	v4l2-ctl --set-ctrl white_balance_auto_preset=0 -d /dev/video0
+	echo "Detected AR0144 - setting brightness"
+	v4l2-ctl --set-ctrl brightness=256 -d ${mipi_video_dev}
 fi
 if [[ "$media_ctl" == *"ar1335"* ]]; then
 	echo "Detected AR1335 - enabling AWB"

--- a/recipes-app/run-1920-1080/files/zub1cg-sbc/run_640_480_yuv422.sh
+++ b/recipes-app/run-1920-1080/files/zub1cg-sbc/run_640_480_yuv422.sh
@@ -5,33 +5,35 @@ OUTPUT_W=640
 OUTPUT_H=480
 OUTPUT_RESOLUTION=${OUTPUT_W}x${OUTPUT_H}
 
-media-ctl -d /dev/media0 -V "'ap1302.0-003c':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+# Specify MIPI capture pipeline devices
+mipi_video_dev="/dev/video0"
+mipi_media_dev="/dev/media0"
+mipi_ap1302_i2c="ap1302.0-003c"
 
-media-ctl -d /dev/media0 -V "'b0000000.mipi_csi2_rx_subsystem':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
-media-ctl -d /dev/media0 -V "'b0000000.mipi_csi2_rx_subsystem':1 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
-
-media-ctl -d /dev/media0 -V "'b0010000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
-media-ctl -d /dev/media0 -V "'b0010000.v_proc_ss':1 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
-
-media-ctl -d /dev/media0 -V "'b0040000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
-media-ctl -d /dev/media0 -V "'b0040000.v_proc_ss':1 [fmt:UYVY8_1X16/$OUTPUT_RESOLUTION field:none]"
-
-sleep 1
+# Configure MIPI capture pipeline for YUV422
+media-ctl -d ${mipi_media_dev} -V "'${mipi_ap1302_i2c}':2 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'b0000000.mipi_csi2_rx_subsystem':1 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'b0010000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'b0010000.v_proc_ss':1 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':0 [fmt:UYVY8_1X16/$INPUT_RESOLUTION field:none]"
+media-ctl -d ${mipi_media_dev} -V "'b0040000.v_proc_ss':1 [fmt:UYVY8_1X16/$OUTPUT_RESOLUTION field:none]"
 
 # Turn off AWB for case of AR0144 sensors (monochrome)
-media_ctl=$(media-ctl -p -d /dev/media0)
+media_ctl=$(media-ctl -p -d ${mipi_media_dev})
 if [[ "$media_ctl" == *"ar0144"* ]]; then
 	echo "Detected AR0144 - disabling AWB"
-	v4l2-ctl --set-ctrl white_balance_auto_preset=0 -d /dev/video0
+	v4l2-ctl --set-ctrl white_balance_auto_preset=0 -d ${mipi_video_dev}
 	echo "Detected AR0144 - setting brightness"
 	v4l2-ctl --set-ctrl brightness=256 -d ${mipi_video_dev}
 fi
 if [[ "$media_ctl" == *"ar1335"* ]]; then
 	echo "Detected AR1335 - enabling AWB"
-	v4l2-ctl --set-ctrl white_balance_auto_preset=1 -d /dev/video0
+	v4l2-ctl --set-ctrl white_balance_auto_preset=1 -d ${mipi_video_dev}
 fi
 
-gst-launch-1.0 v4l2src device=/dev/video0 io-mode="dmabuf" \
+# Launch gstreamer pipeline
+gst-launch-1.0 v4l2src device=${mipi_video_dev} io-mode="dmabuf" \
 	! "video/x-raw, width=$OUTPUT_W, height=$OUTPUT_H, format=YUY2, framerate=60/1" \
 	! videoconvert \
 	! fpsdisplaysink video-sink="autovideosink" text-overlay=false sync=false \

--- a/recipes-app/run-1920-1080/run-1920-1080.bb
+++ b/recipes-app/run-1920-1080/run-1920-1080.bb
@@ -10,7 +10,8 @@ SRC_URI:u96v2-sbc = "file://run_1920_1080.sh \
                      file://optimize_qos_for_dp.sh \
 "
 
-SRC_URI:zub1cg-sbc = "file://run_640_480.sh \
+SRC_URI:zub1cg-sbc = "file://run_640_480_rgb.sh \
+                      file://run_640_480_yuv422.sh \
                       file://run_1280_480_rgb.sh \
                       file://run_1280_480_yuv422.sh \
                       file://run_1920_1080_rgb.sh \
@@ -31,7 +32,8 @@ do_install:u96v2-sbc() {
 
 do_install:append:zub1cg-sbc() {
     install -d ${D}${bindir}
-    install -m 0755 ${WORKDIR}/run_640_480.sh ${D}${bindir}/run_640_480
+    install -m 0755 ${WORKDIR}/run_640_480_rgb.sh ${D}${bindir}/run_640_480_rgb
+    install -m 0755 ${WORKDIR}/run_640_480_yuv422.sh ${D}${bindir}/run_640_480_yuv422
     install -m 0755 ${WORKDIR}/run_1280_480_rgb.sh ${D}${bindir}/run_1280_480_rgb
     install -m 0755 ${WORKDIR}/run_1280_480_yuv422.sh ${D}${bindir}/run_1280_480_yuv422
     install -m 0755 ${WORKDIR}/run_1920_1080_rgb.sh ${D}${bindir}/run_1920_1080_rgb
@@ -45,7 +47,8 @@ FILES:${PN}:u96v2-sbc = "${bindir}/run_1920_1080 \
                          ${bindir}/optimize_qos_for_dp \
 "
 
-FILES:${PN}:zub1cg-sbc = "${bindir}/run_640_480 \
+FILES:${PN}:zub1cg-sbc = "${bindir}/run_640_480_rgb \
+                          ${bindir}/run_640_480_yuv422 \
                           ${bindir}/run_1280_480_rgb \
                           ${bindir}/run_1280_480_yuv422 \
                           ${bindir}/run_1920_1080_rgb \


### PR DESCRIPTION
Small changes to tidy up the scripts for passing through the camera's output to a X11 window for ZUB1CG board. 

Tested each script and got a valid video output. 

Turns out it was an issue with J4 and v1.8 MIPI logic, which prevented the video capture pipeline from working.  Thanks Michael for testing this many times for me!